### PR TITLE
Timer page bug fix

### DIFF
--- a/timer/index.html
+++ b/timer/index.html
@@ -33,7 +33,7 @@
 
 
 <body class='d-flex flex-column align-items-center justify-content-center'>
-    <a href="/" class="back-link">
+    <a href="/website" class="back-link">
         <div class="back"></div>
     </a>
     <!-- <div class="fonty"><i class="fa fa-chevron-left" aria-hidden="true"></i> -->


### PR DESCRIPTION
When hosting on github.io the home route is `/website` , and not `/` therefore the current deployment is broken when u try to click the back arrow on the `/timer` page, This PR hopes to fix that 

Fix #23 